### PR TITLE
Support multiple paths in FAB_PLAN_INLUDE_PATH

### DIFF
--- a/pylib/cpp.py
+++ b/pylib/cpp.py
@@ -65,7 +65,8 @@ def cpp(input, cpp_opts=[]):
 
     include_path = os.environ.get('FAB_PLAN_INCLUDE_PATH')
     if include_path:
-        args.append("-I" + include_path)
+        for path in include_path.split(':'):
+            args.append("-I" + path)
 
     command = ["cpp", input]
     if args:


### PR DESCRIPTION
I guess this is a poor version of overlays. Allowing two items in FAB_PLAN_INCLUDE_PATH means that the end-user can write a plan snippet which overrides something from within $(FAB_PATH)/common/plans, without needing to duplicate the whole tree (and keep it up to date).

My use-case for this is actually to remove a single package (udhcpc) from the default set which is otherwise OK.
