### PR TITLE
Buster dev

### DIFF
--- a/pylib/installer.py
+++ b/pylib/installer.py
@@ -132,7 +132,7 @@ class Installer(object):
         for packages in (high, regular):
             if packages:
                 try:
-                    args = ['install', '--force-yes', '--assume-yes']
+                    args = ['install', '--assume-yes']
                     args.extend(extra_apt_args)
                     self.chroot.system("apt-get", *(args + packages))
                 except executil.ExecError, e:
@@ -208,17 +208,23 @@ class PoolInstaller(Installer):
         def md5sum(path):
             return str(hashlib.md5(open(path, 'rb').read()).hexdigest())
 
+        def sha256sum(path):
+            return str(hashlib.sha256(open(path, 'rb').read()).hexdigest())
+
         index = []
         for package in os.listdir(packagedir):
             path = os.path.join(packagedir, package)
+            # dl_path would best be calculated; but we don't have access to chroot_path here...
+            dl_path = os.path.join('var/cache/apt/archives', package)
             if path.endswith('.deb'):
                 control = debinfo.get_control_fields(path)
                 for field in control.keys():
                     index.append(field + ": " + control[field])
 
-                index.append("Filename: " + path)
+                index.append("Filename: " + dl_path)
                 index.append("Size: " + filesize(path))
                 index.append("MD5sum: " + md5sum(path))
+                index.append("SHA256: " + sha256sum(path))
                 index.append("")
 
         return index

--- a/share/bootstrap.mk
+++ b/share/bootstrap.mk
@@ -1,5 +1,5 @@
 #!/usr/bin/make -f
-# Copyright (c) TurnKey GNU/Linux - http://www.turnkeylinux.org
+# Copyright (c) TurnKey GNU/Linux - https://www.turnkeylinux.org
 #
 # This file is part of Fab
 #
@@ -28,7 +28,7 @@ POOL ?= $(FAB_PATH)/pools/$(CODENAME)
 export FAB_POOL_PATH = $(POOL)
 
 FAB_ARCH = $(shell dpkg --print-architecture)
-DEBOOTSTRAP_SUITE ?= generic
+DEBOOTSTRAP_SUITE ?= turnkey
 
 # build output path
 O ?= build
@@ -121,7 +121,6 @@ define bootstrap/body
 	$(BSP)/exclude_spec.py $O/base.spec $O/required.spec > $O/base-excl-req.spec
 	$(BSP)/debootstrap.py $(FAB_ARCH) $(DEBOOTSTRAP_SUITE) $O/bootstrap `pwd`/$O/repo $O/required.spec $O/base-excl-req.spec
 
-	fab-chroot $O/bootstrap --script $(BSP)/cleanup.sh
 	fab-chroot $O/bootstrap 'echo "do_initrd = Yes" > /etc/kernel-img.conf'
 endef
 

--- a/share/bootstrap/debootstrap.py
+++ b/share/bootstrap/debootstrap.py
@@ -11,8 +11,7 @@
 import os
 import sys
 from os.path import *
-
-from executil import system
+import subprocess
 
 def usage(s=None):
     if s: print >> sys.stderr, s
@@ -24,6 +23,7 @@ def get_packages(spec_file):
              for line in file(spec_file).readlines() ]
 
 def main():
+
     args = sys.argv[1:]
     if len(args) != 6:
         usage()
@@ -34,7 +34,7 @@ def main():
     os.environ["BASE_PACKAGES"] = " ".join(get_packages(base_spec))
     repo = abspath(repo)
 
-    system("debootstrap --arch %s %s %s file://%s" % (arch, suite, target, repo))
+    subprocess.check_output(["debootstrap", "--arch", arch, suite, target, "file://"+repo])
 
 if __name__=="__main__":
     main()

--- a/share/product.mk
+++ b/share/product.mk
@@ -108,7 +108,7 @@ UNIT_DIRS ?= unit.d
 CONF_SCRIPTS ?= conf.d
 PATCHES_PATH ?= patches.d
 
-INITRAMFS_PACKAGES ?= busybox-initramfs casper
+INITRAMFS_PACKAGES ?= busybox live-boot
 
 # build output path
 O ?= build
@@ -437,10 +437,10 @@ cdroot/deps ?= $(STAMPS_DIR)/root.patched $(_CDROOT)
 define cdroot/body
 	if [ -e $O/cdroot ]; then rm -rf $O/cdroot; fi
 	cp -a $(_CDROOT) $O/cdroot
-	mkdir $O/cdroot/casper
+	mkdir $O/cdroot/live
 	if [ -d $(CDROOT_OVERLAY) ]; then fab-apply-overlay $(CDROOT_OVERLAY) $O/cdroot; fi
 
-	$(MKSQUASHFS) $O/root.patched $O/cdroot/casper/10root.squashfs $(MKSQUASHFS_OPTS)
+	$(MKSQUASHFS) $O/root.patched $O/cdroot/live/10root.squashfs $(MKSQUASHFS_OPTS)
 endef
 
 define run-genisoimage
@@ -475,15 +475,15 @@ define cdroot-dynamic/body
 	cp $O/root.sandbox/usr/lib/syslinux/modules/bios/libcom32.c32 $O/cdroot/isolinux
 	cp $O/root.sandbox/usr/lib/syslinux/modules/bios/vesamenu.c32 $O/cdroot/isolinux
 	cp $O/root.sandbox/usr/lib/syslinux/modules/bios/gfxboot.c32 $O/cdroot/isolinux
-	cp $O/root.sandbox/boot/$(shell basename $(shell readlink $O/root.sandbox/vmlinuz)) $O/cdroot/casper/vmlinuz
-	cp $O/root.sandbox/boot/$(shell basename $(shell readlink $O/root.sandbox/initrd.img)) $O/cdroot/casper/initrd.gz
+	cp $O/root.sandbox/boot/$(shell basename $(shell readlink $O/root.sandbox/vmlinuz)) $O/cdroot/live/vmlinuz
+	cp $O/root.sandbox/boot/$(shell basename $(shell readlink $O/root.sandbox/initrd.img)) $O/cdroot/live/initrd.gz
 
-	rm -f $O/cdroot/casper/20sandbox.squashfs
+	rm -f $O/cdroot/live/20sandbox.squashfs
 	@if deck --isdirty $O/root.sandbox; then \
 		$(call root-cleanup, $O/root.sandbox) \
 		\
 		get_last_level="deck --get-level=last $O/root.sandbox"; \
-		output=$O/cdroot/casper/20sandbox.squashfs; \
+		output=$O/cdroot/live/20sandbox.squashfs; \
 		echo "mksquashfs \$$($$get_last_level) $$output"; \
 		\
 		last_level=$$($$get_last_level); \
@@ -504,7 +504,7 @@ define updated-initramfs/body
 	rm -rf $O/product.iso
 	$(root.patched/body)
 	fab-install $$FAB_INSTALL_OPTS $O/root.patched $(INITRAMFS_PACKAGES)
-	cp $O/root.patched/boot/$(shell basename $(shell readlink $O/root.patched/initrd.img)) $O/cdroot/casper/initrd.gz
+	cp $O/root.patched/boot/$(shell basename $(shell readlink $O/root.patched/initrd.img)) $O/cdroot/live/initrd.gz
 	$(run-genisoimage)
 endef
 


### PR DESCRIPTION
Please note that this update requires the ['turnkey' debootstrap script](https://github.com/turnkeylinux-apps/tkldev/blob/master/overlay/usr/share/debootstrap/scripts/turnkey).

Mostly it should be backwards compatible with v15.x / Debian 9/Stretch. However the changes to `product.mk` may break the ability to build a v15.x / Stretch ISO because of the switch from `casper` to the Debian `live` system. I haven't tested that and IMO it's a small price to pay to push forward with Buster! (Worst case scenario, reinstall Fab from the repo).