### PR TITLE
Add 'altstrap' functionality

### DIFF
--- a/share/product.mk
+++ b/share/product.mk
@@ -61,6 +61,10 @@ export FAB_INSTALL_ENV = $(FAB_CHROOT_ENV)
 # FAB_PATH dependent infrastructural components
 FAB_SHARE_PATH ?= /usr/share/fab
 BOOTSTRAP ?= $(FAB_PATH)/bootstraps/$(CODENAME)
+ifneq ("$(wildcard $(FAB_PATH)/altstraps/$(CODENAME).core)", "")
+	BOOTSTRAP := $(FAB_PATH)/altstraps/$(CODENAME).core
+endif
+
 CDROOTS_PATH ?= $(FAB_PATH)/cdroots
 CDROOT ?= generic
 MKSQUASHFS ?= /usr/bin/mksquashfs


### PR DESCRIPTION
When building an appliance, this change will check for an alternate ``strap`` (alternative to the bootstrap) in ``/turnkey/fab/altstraps/$RELEASE.strapname`` so far only ``corestrap`` has been implemented.

To use corestrap do the following:

```bash
cd core #/turnkey/fab/products/core
make clean
make root.build
mkdir -p /turnkey/fab/altstraps
cp -ar build/root.build /turnkey/fab/altstraps/buster.core #note the -a is important here, otherwise permissions in the new corestrap will be broken
```