### PR TITLE
Revert to non-uefi boot for v17.x (not going to make it in).

### DIFF
--- a/share/product.mk
+++ b/share/product.mk
@@ -456,6 +456,18 @@ define cdroot/body
 endef
 
 define run-genisoimage
+    xorriso -as mkisofs \
+        -o $O/product.iso -r -J \
+        -V ${ISOLABEL} \
+        -b isolinux/isolinux.bin \
+        -c isolinux/boot.cat \
+        -no-emul-boot \
+        -boot-load-size 4 \
+        -boot-info-table \
+        $O/cdroot/
+endef
+
+define run-genisoimage-uefi
 	xorriso -as mkisofs \
 		-o $O/product.iso -r -J \
 		-V ${ISOLABEL} \


### PR DESCRIPTION
This commit changes the default back to creation of a syslinux only boot (i.e. not UEFI boot support). As you can see, I've renamed the target, so the updated code is still there, just under a different name...