### PR TITLE
WIP: Rebuild steps even with stamp

### DIFF
--- a/share/product.mk
+++ b/share/product.mk
@@ -281,7 +281,7 @@ define root.spec/body
 endef
 
 # target: root.build
-root.build/deps ?= $(STAMPS_DIR)/bootstrap $(STAMPS_DIR)/root.spec
+root.build/deps ?= $O/bootstrap $(STAMPS_DIR)/bootstrap $(STAMPS_DIR)/root.spec
 define root.build/init
 	if ! deck --isdeck $O/root.build; then deck $O/bootstrap $O/root.build; fi
 endef
@@ -436,7 +436,7 @@ define root.patched/cleanup
 endef
 
 # target root.sandbox
-root.sandbox/deps ?= $(STAMPS_DIR)/root.patched
+root.sandbox/deps ?= $O/root.patched $(STAMPS_DIR)/root.patched
 define root.sandbox/body
 	$(call remove-deck, $O/root.sandbox)
 	deck $O/root.patched $O/root.sandbox
@@ -445,7 +445,7 @@ endef
 ifndef CHROOT_ONLY
 
 # target: cdroot
-cdroot/deps ?= $(STAMPS_DIR)/root.patched $(_CDROOT)
+cdroot/deps ?= $O/root.patched $(STAMPS_DIR)/root.patched $(_CDROOT)
 define cdroot/body
 	if [ -e $O/cdroot ]; then rm -rf $O/cdroot; fi
 	cp -a $(_CDROOT) $O/cdroot


### PR DESCRIPTION
fab uses stamps to check if each deck is built or not. This is required as existing deck's could of failed and still exist. However when a stamp exists and the deck does not, it still thinks it does not need to rebuild.

By making each stage dependent on both the stamp AND deck of the previous step, stages will be rebuilt in this condition without having to manually remove the stamp.

(note this hasn't been extensively tested yet)