### PR TITLE
Clean default clicksnap screenshot dir when running 'make clean'

### DIFF
--- a/share/product.mk
+++ b/share/product.mk
@@ -255,7 +255,7 @@ define clean/body
 	$(call remove-deck, $O/root.patched)
 	$(call remove-deck, $O/root.build)
 	$(call remove-deck, $O/bootstrap)
-	-rm -rf $O/root.spec $O/cdroot $O/product.iso $O/log $(STAMPS_DIR)
+	-rm -rf $O/root.spec $O/cdroot $O/product.iso $O/log $O/screens $(STAMPS_DIR)
 endef
 
 clean:


### PR DESCRIPTION
Minor change to `product.mk` to clean up the `build/screens` dir when running `make clean` (in the base product buildcode dir - e.g. `$FAB_PATH/products/core`).

Note the `build/screens` dir is the (new) default dir for screenshots taken by `clicksnap` during build appliance build using `bt-iso`.