### PR TITLE
Include syslinux-utils as recommends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Depends:
  pool
 Recommends:
  xorriso,
+ syslinux-utils,
  squashfs-tools
 Suggests:
  dd,


### PR DESCRIPTION
Minor tweak to include `syslinux-utils` as recommends.