### PR TITLE
Support for `arm64`

### DIFF
--- a/contrib/install-arm-on-amd-deps
+++ b/contrib/install-arm-on-amd-deps
@@ -22,9 +22,10 @@ args::
 
 env vars::
 
-    DEBUG       verbose output - overrides -q|--quiet
+    DEBUG       verbose debugging output - overrides -q|--quiet
 
 EOF
+    exit
 }
 
 while [[ $# -ne 0 ]]; do
@@ -41,7 +42,7 @@ while [[ $# -ne 0 ]]; do
 done
 
 for i in "${!pkgs[@]}"; do
-    if ! which "${bins[$i]}"; then
+    if ! which "${bins[$i]}" >/dev/null 2>&1; then
         pkgs_to_install+=("${pkgs[$i]}")
     fi
 done

--- a/contrib/install-arm-on-amd-deps
+++ b/contrib/install-arm-on-amd-deps
@@ -1,0 +1,64 @@
+#!/bin/bash -eu
+
+DEBUG=${DEBUG:-}
+[[ -z "$DEBUG" ]] || set -x
+
+QUIET=
+pkgs=(binfmt-support qemu-system-arm qemu-user-static)
+bins=(/usr/sbin/update-binfmts /usr/bin/qemu-system-arm /usr/bin/qemu-arm-static)
+pkgs_to_install=()
+
+usage() {
+    cat <<EOF
+$(basename "$0") [-h|--help] [-q|--quiet]
+
+Checks packages required to build arm64 on amd64 are installed
+and if not, installs them.
+
+args::
+
+    -h|--help   show this help and exit
+    -q|--quiet  no output
+
+env vars::
+
+    DEBUG       verbose output - overrides -q|--quiet
+
+EOF
+}
+
+while [[ $# -ne 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage;;
+        -q|--quiet)
+            QUIET=q;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1;;
+    esac
+    shift
+done
+
+for i in "${!pkgs[@]}"; do
+    if ! which "${bins[$i]}"; then
+        pkgs_to_install+=("${pkgs[$i]}")
+    fi
+done
+
+set +u # unset u - otherwise the test will give an "unbound variable" error
+# shellcheck disable=SC2128
+# even if there are no elements in a array; ${foo[@]} still isn't "empty"
+if [[ -n "$pkgs_to_install" ]]; then
+    if [[ -n "$QUIET" ]]; then
+        echo "Installing: ${pkgs_to_install[*]}"
+        apt-get update
+        apt-get install -y "${pkgs_to_install[@]}"
+        echo ""
+    else
+        apt-get update >/dev/null 2>&1
+        apt-get install -y "${pkgs_to_install[@]}" >/dev/null 2>&1
+    fi
+fi
+
+update-binfmts --display | grep -i"$QUIET" aarch

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends:
 Standards-Version: 4.0.0
 
 Package: fab
-Architecture: any
+Architecture: all
 Depends:
  cpp,
  ${misc:Depends},

--- a/debian/control
+++ b/debian/control
@@ -25,4 +25,7 @@ Recommends:
 Suggests:
  dd,
  wodim,
+ binfmt-support,
+ qemu-system-arm,
+ qemu-user-static
 Description: TurnKey GNU/Linux product fabrication framework

--- a/debian/install
+++ b/debian/install
@@ -1,2 +1,3 @@
 share/*     usr/share/fab
 contrib/fab-* usr/bin
+contrib/install-arm-on-amd-deps   usr/bin

--- a/fab
+++ b/fab
@@ -378,20 +378,6 @@ def add_cpp_opts(parser: ArgumentParser) -> None:
     )
 
 
-def get_arch() -> str:
-    fab_arch = os.getenv("FAB_ARCH", "")
-    if os.getenv("ARM_ON_AMD", ""):
-        return "arm64"
-    elif fab_arch:
-        return fab_arch
-    else:
-        return subprocess.run(
-                ["dpkg", "--print-architecture"],
-                capture_output=True,
-                text=True
-                ).stdout.strip()
-
-
 if __name__ == "__main__":
     parser = ArgumentParser(
         formatter_class=RawDescriptionHelpFormatter,
@@ -483,13 +469,6 @@ Configuration environment variables:
     )
     chroot_parser.add_argument(
         "args", metavar="ARG", nargs="*", help="script arguments"
-    )
-    chroot_parser.add_argument(
-        "-a",
-        "--arch",
-        metavar="FAB_ARCH",
-        help="Architecture of chroot\ndefault: $FAB_CHROOT_ENV",
-        default=get_arch()
     )
 
     install_parser = subparsers.add_parser(

--- a/fab
+++ b/fab
@@ -25,7 +25,7 @@ import sys
 import os
 from os.path import isdir, join, basename, relpath
 
-from debian import debfile
+from debian import debfile, deb822
 
 from fablib.installer import (PoolInstaller,
                               LiveInstaller, Installer)
@@ -96,7 +96,7 @@ class AssociatedAppendAction(argparse.Action):
             setattr(namespace, self.dest, [(option_string, values)])
 
 
-def generate_index(dctrls: Dict[Dependency, debfile.Deb822]) -> str:
+def generate_index(dctrls: Dict[Dependency, deb822.Deb822]) -> str:
     fields = (
         "Package",
         "Essential",
@@ -378,6 +378,20 @@ def add_cpp_opts(parser: ArgumentParser) -> None:
     )
 
 
+def get_arch() -> str:
+    fab_arch = os.getenv("FAB_ARCH", "")
+    if os.getenv("ARM_ON_AMD", ""):
+        return "arm64"
+    elif fab_arch:
+        return fab_arch
+    else:
+        return subprocess.run(
+                ["dpkg", "--print-architecture"],
+                capture_output=True,
+                text=True
+                ).stdout.strip()
+
+
 if __name__ == "__main__":
     parser = ArgumentParser(
         formatter_class=RawDescriptionHelpFormatter,
@@ -469,6 +483,13 @@ Configuration environment variables:
     )
     chroot_parser.add_argument(
         "args", metavar="ARG", nargs="*", help="script arguments"
+    )
+    chroot_parser.add_argument(
+        "-a",
+        "--arch",
+        metavar="FAB_ARCH",
+        help="Architecture of chroot\ndefault: $FAB_CHROOT_ENV",
+        default=get_arch()
     )
 
     install_parser = subparsers.add_parser(

--- a/share/product.mk
+++ b/share/product.mk
@@ -81,7 +81,7 @@ endif
 
 COMMON_PATCHES := turnkey.d $(COMMON_PATCHES)
 
-CONF_VARS_BUILTIN ?= FAB_ARCH FAB_HTTP_PROXY I386 AMD64 ARM64 RELEASE DISTRO CODENAME DEBIAN UBUNTU KERNEL DEBUG CHROOT_ONLY
+CONF_VARS_BUILTIN ?= FAB_ARCH HOST_ARCH FAB_HTTP_PROXY I386 AMD64 ARM64 RELEASE DISTRO CODENAME DEBIAN UBUNTU KERNEL DEBUG CHROOT_ONLY
 
 define filter-undefined-vars
 	$(foreach var,$1,$(if $($(var)), $(var)))
@@ -98,11 +98,11 @@ export FAB_INSTALL_ENV = $(FAB_CHROOT_ENV)
 FAB_SHARE_PATH ?= /usr/share/fab
 BOOTSTRAP ?= $(FAB_PATH)/bootstraps/$(CODENAME)-$(FAB_ARCH)
 ifneq ("$(wildcard $(FAB_PATH)/altstraps/$(CODENAME)-$(FAB_ARCH).core)", "")
-	BOOTSTRAP := $(FAB_PATH)/altstraps/$(CODENAME)-$(FAB_ARCH).core
+BOOTSTRAP := $(FAB_PATH)/altstraps/$(CODENAME)-$(FAB_ARCH).core
 endif
-ifneq (,$(wildcard $(BOOTSTRAP)))
-	$(error bootstrap $(BOOTSTRAP) not found)
-endif)
+ifeq (,"$(wildcard $(BOOTSTRAP)"))
+$(error bootstrap $(BOOTSTRAP) not found - download or build it first)
+endif
 
 CDROOTS_PATH ?= $(FAB_PATH)/cdroots
 CDROOT ?= generic

--- a/share/product.mk
+++ b/share/product.mk
@@ -35,7 +35,6 @@ CODENAME ?= $(shell basename $(RELEASE))
 UBUNTU = $(shell [ $(DISTRO) = 'ubuntu' ] && echo 'y')
 DEBIAN = $(shell [ $(DISTRO) = 'debian' ] && echo 'y')
 
-I386 = $(shell [ $(FAB_ARCH) = 'i386' ] && echo 'y')
 AMD64 = $(shell [ $(FAB_ARCH) = 'amd64' ] && echo 'y')
 ARM64 = $(shell [ $(FAB_ARCH) = 'arm64' ] && echo 'y')
 
@@ -79,7 +78,7 @@ endif
 
 COMMON_PATCHES := turnkey.d $(COMMON_PATCHES)
 
-CONF_VARS_BUILTIN ?= FAB_ARCH HOST_ARCH FAB_HTTP_PROXY I386 AMD64 ARM64 RELEASE DISTRO CODENAME DEBIAN UBUNTU KERNEL DEBUG CHROOT_ONLY
+CONF_VARS_BUILTIN ?= FAB_ARCH HOST_ARCH FAB_HTTP_PROXY AMD64 ARM64 RELEASE DISTRO CODENAME DEBIAN UBUNTU KERNEL DEBUG CHROOT_ONLY
 
 define filter-undefined-vars
 	$(foreach var,$1,$(if $($(var)), $(var)))

--- a/share/product.mk
+++ b/share/product.mk
@@ -8,6 +8,8 @@
 # Free Software Foundation; either version 3 of the License, or (at your
 # option) any later version.
 
+HOST_ARCH := $(shell dpkg --print-architecture)
+
 ifndef FAB_PATH
 $(error FAB_PATH not defined - needed for default paths)
 endif
@@ -16,13 +18,24 @@ ifndef RELEASE
 $(error RELEASE not defined)
 endif
 
+ifdef FAB_ARCH
+ifneq ($(FAB_ARCH),$(HOST_ARCH))
+$(info building $(FAB_ARCH) on $(HOST_ARCH))
+ifeq ($(HOST_ARCH),arm64)
+$(error amd64 product can not be built on arm64)
+else
+ARM_ON_AMD := y
+endif
+endif
+else
+FAB_ARCH := $(HOST_ARCH)
+endif
+
 DISTRO ?= $(shell dirname $(RELEASE))
 CODENAME ?= $(shell basename $(RELEASE))
 
 UBUNTU = $(shell [ $(DISTRO) = 'ubuntu' ] && echo 'y')
 DEBIAN = $(shell [ $(DISTRO) = 'debian' ] && echo 'y')
-
-FAB_ARCH ?= $(shell dpkg --print-architecture)
 
 I386 = $(shell [ $(FAB_ARCH) = 'i386' ] && echo 'y')
 AMD64 = $(shell [ $(FAB_ARCH) = 'amd64' ] && echo 'y')
@@ -31,12 +44,15 @@ ARM64 = $(shell [ $(FAB_ARCH) = 'arm64' ] && echo 'y')
 ifndef FAB_ARCH_FAMILY
 ifeq ($(I386),y)
 FAB_ARCH_FAMILY=x86
+FAB_INSTALL_OPTS := '--arch i386'
 endif
 ifeq ($(AMD64),y)
 FAB_ARCH_FAMILY=x86
+FAB_INSTALL_OPTS := '--arch amd64'
 endif
 ifeq ($(ARM64),y)
 FAB_ARCH_FAMILY=arm
+FAB_INSTALL_OPTS := '--arch arm64'
 # NONFREE is used to get raspi-firmware and firmware-brcm80211
 # NONFREE=1
 endif
@@ -52,7 +68,7 @@ export FAB_POOL_PATH
 endif
 
 ifdef FAB_POOL_PATH
-FAB_INSTALL_OPTS = '--no-deps'
+FAB_INSTALL_OPTS += '--no-deps'
 endif
 
 ifndef FAB_HTTP_PROXY
@@ -80,10 +96,13 @@ export FAB_INSTALL_ENV = $(FAB_CHROOT_ENV)
 
 # FAB_PATH dependent infrastructural components
 FAB_SHARE_PATH ?= /usr/share/fab
-BOOTSTRAP ?= $(FAB_PATH)/bootstraps/$(CODENAME)
-ifneq ("$(wildcard $(FAB_PATH)/altstraps/$(CODENAME).core)", "")
-	BOOTSTRAP := $(FAB_PATH)/altstraps/$(CODENAME).core
+BOOTSTRAP ?= $(FAB_PATH)/bootstraps/$(CODENAME)-$(FAB_ARCH)
+ifneq ("$(wildcard $(FAB_PATH)/altstraps/$(CODENAME)-$(FAB_ARCH).core)", "")
+	BOOTSTRAP := $(FAB_PATH)/altstraps/$(CODENAME)-$(FAB_ARCH).core
 endif
+ifneq (,$(wildcard $(BOOTSTRAP)))
+	$(error bootstrap $(BOOTSTRAP) not found)
+endif)
 
 CDROOTS_PATH ?= $(FAB_PATH)/cdroots
 CDROOT ?= generic
@@ -123,7 +142,7 @@ PLAN ?= plan/main
 ROOT_OVERLAY ?= overlay
 CDROOT_OVERLAY ?= cdroot.overlay
 REMOVELIST ?= removelist
-# undefine REMOVELIST if the file doesn't exist
+# unset REMOVELIST if the file doesn't exist
 ifeq ($(wildcard $(REMOVELIST)),)
 REMOVELIST =
 endif
@@ -153,6 +172,7 @@ define remove-deck
 	fi
 endef
 
+$(info GOT_TO_HERE)
 ifdef CHROOT_ONLY
 all: root.sandbox
 else

--- a/share/product.mk
+++ b/share/product.mk
@@ -23,8 +23,6 @@ ifneq ($(FAB_ARCH),$(HOST_ARCH))
 $(info building $(FAB_ARCH) on $(HOST_ARCH))
 ifeq ($(HOST_ARCH),arm64)
 $(error amd64 product can not be built on arm64)
-else
-ARM_ON_AMD := y
 endif
 endif
 else
@@ -172,7 +170,6 @@ define remove-deck
 	fi
 endef
 
-$(info GOT_TO_HERE)
 ifdef CHROOT_ONLY
 all: root.sandbox
 else


### PR DESCRIPTION
- Update `debian/control` "suggests" to include dependencies for building `arm64` on `amd64` host.
- Add contrib script to install "`arm64` on `amd64` dependencies if/when needed.
- Further updates to `product.mk` for building `arm64` on `amd64`.