### PR TITLE
set arch as 'all'

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends:
 Standards-Version: 4.0.0
 
 Package: fab
-Architecture: any
+Architecture: all
 Depends:
  cpp,
  ${misc:Depends},


### PR DESCRIPTION
super minimal change:
- build `all` package - `any` builds arch specific package for each arch