### PR TITLE
Force pybuild to not create __pycache__ files at build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,11 +1,6 @@
 #! /usr/bin/make -f
 
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-
-DPKG_EXPORT_BUILDFLAGS = 1
-
-include /usr/share/dpkg/pkg-info.mk
-include /usr/share/dpkg/buildflags.mk
+export PYTHONDONTWRITEBYTECODE=1
 
 %:
 	dh $@ --buildsystem=pybuild


### PR DESCRIPTION
Minimal change to make fab reproducible.

FYI `DEB_BUILD_MAINT_OPTIONS`, `DPKG_EXPORT_BUILDFLAGS` & `/usr/share/dpkg/buildflags.mk` are only relevant to packages that are built from C/C++ source and have no impact on pure python source. `/usr/share/dpkg/pkg-info.mk` just sets some package info env vars which don't appear to be required for our purposes.
