### PR TITLE
Support for DI_LIVE_DEBUG env var

### DIFF
--- a/fab
+++ b/fab
@@ -324,7 +324,9 @@ def cmd_apply_overlay(
         overlay: str,
         dstpath: str,
         preserve: bool = False) -> None:
-
+    if not isdir(overlay):
+        print(f"Skipping {overlay} because it is not a directory")
+        return None
     cmd = ['cp', '-TdR']
     if preserve:
         cmd.append('-p')

--- a/share/product.mk
+++ b/share/product.mk
@@ -69,7 +69,7 @@ endif
 
 COMMON_PATCHES := turnkey.d $(COMMON_PATCHES)
 
-CONF_VARS_BUILTIN ?= FAB_ARCH HOST_ARCH FAB_HTTP_PROXY AMD64 ARM64 RELEASE DISTRO CODENAME DEBIAN UBUNTU KERNEL DEBUG CHROOT_ONLY
+CONF_VARS_BUILTIN ?= FAB_ARCH HOST_ARCH FAB_HTTP_PROXY AMD64 ARM64 RELEASE DISTRO CODENAME DEBIAN UBUNTU KERNEL DEBUG CHROOT_ONLY DI_LIVE_DEBUG
 
 define filter-undefined-vars
 	$(foreach var,$1,$(if $($(var)), $(var)))
@@ -245,6 +245,7 @@ define help/body
 	@echo
 	@echo '# Built-in configuration options:'
 	@echo '  DEBUG                      Turn on product debugging'
+	@echo '  DI_LIVE_DEBUG              Set kernel commandline options for debugging di-live'
 	@echo '  KERNEL                     Override default kernel package'
 	@echo '  EXTRA_PLAN                 Extra packages to include in the plan'
 	@echo '  CHROOT_ONLY                Build a chroot-only product'


### PR DESCRIPTION
Very minor update to support setting `DI_LIVE_DEBUG` env var. When set it will update the grub kernel cmdline with some options to support di-live debugging from an iso.

I will update the common `conf/turnkey.d/grub-debug` config script to actually add the relevant grub kernel cmdline options, but that will be in another PR (against common) once I complete everything in my current dev branch...

[update] I've also added another commit that explicitly refuses to apply an overlay if it is not a directory. It won't apply a overlay if it's a file anyway, but this makes it clear why it won't.