### PR TITLE
fix: plan-resolve silently drops packages not in pool

### DIFF
--- a/fablib/plan.py
+++ b/fablib/plan.py
@@ -352,7 +352,7 @@ class Plan:
 
         return dctrls
 
-    def resolve(self) -> tuple[Iterable[str], Iterable[str]]:
+    def resolve(self, bootstrap_provided: set[str] | None = None) -> tuple[Iterable[str], Iterable[str]]:
         """resolve plan dependencies recursively -> return spec"""
         logger.debug("resolve")
 
@@ -364,7 +364,7 @@ class Plan:
 
         resolved: set[Dependency] = set()
         missing: set[Dependency] = set()
-        provided: set[str] = set()
+        provided: set[str] = set(bootstrap_provided or set())
 
         def reformat2dep(pkg: str) -> str:
             if "=" not in pkg:
@@ -402,8 +402,10 @@ class Plan:
                 )
                 provided |= self._get_provided(pkg_control)
 
+            missing |= packages.missing
             unresolved = new_deps - resolved
-            all_missing = set(map(str, (missing | packages.missing))) - provided
+
+        all_missing = set(map(str, missing)) - provided
 
         if all_missing:
 
@@ -417,9 +419,7 @@ class Plan:
                     except KeyError:
                         depname = None
 
-            brokendeps = []
-            for dep in missing:
-                brokendeps.append(dep.name)
+            brokendeps = [dep.name for dep in missing if str(dep) in all_missing]
 
             logger.debug(
                 f"could not find these packages in pool: {brokendeps!r}"

--- a/fablib/resolve.py
+++ b/fablib/resolve.py
@@ -7,6 +7,8 @@ from debian.deb822 import Deb822
 
 from .plan import PackageOrigins, Plan
 
+import re
+
 logger = logging.getLogger("fab.resolve")
 
 
@@ -18,6 +20,25 @@ def iter_packages(root: str) -> Generator[str, None, None]:
                 deb = Deb822(control.splitlines())
                 if deb["Status"] == "install ok installed":
                     yield deb["Package"]
+                control = ""
+            else:
+                control += line
+
+
+def iter_provided(root: str) -> Generator[str, None, None]:
+    """Yield virtual package names provided by installed bootstrap packages."""
+    control = ""
+    with open(join(root, "var/lib/dpkg/status")) as fob:
+        for line in fob:
+            if not line.strip():
+                deb = Deb822(control.splitlines())
+                if deb["Status"] == "install ok installed":
+                    provides = deb.get("Provides", "")
+                    if provides:
+                        for p in re.split(r"\s*,\s*", provides.strip()):
+                            name = p.split()[0].strip()
+                            if name:
+                                yield name
                 control = ""
             else:
                 control += line
@@ -54,8 +75,10 @@ def resolve_plan(
     plans: list[str],
 ) -> None:
     plan = Plan(pool_path=pool_path)
+    bootstrap_provided: set[str] = set()
     if bootstrap_path:
         bootstrap_packages = set(iter_packages(bootstrap_path))
+        bootstrap_provided = set(iter_provided(bootstrap_path))
         plan |= bootstrap_packages
 
         for package in bootstrap_packages:
@@ -72,7 +95,7 @@ def resolve_plan(
             plan.add(plan_path)
             plan.packageorigins.add(plan_path, "_")
 
-    spec, unresolved = plan.resolve()
+    spec, unresolved = plan.resolve(bootstrap_provided=bootstrap_provided)
     logger.debug("unresolved" + "\n".join(unresolved))
     spec = annotate_spec(unresolved, spec, plan.packageorigins)
     logger.debug(spec)


### PR DESCRIPTION
## Summary

`Plan.resolve()` in `fablib/plan.py` silently drops packages from the plan that are not found in the pool, instead of passing them through as repo-installable packages. This causes critical packages like `locales`, `curl`, `nginx`, `git`, `iptables`, `fail2ban`, `postfix`, `ssh`, `build-essential`, `isolinux`, `linux-image-amd64` etc. to be missing from `root.spec`, breaking all appliance builds.

## Root cause

Three bugs in `Plan.resolve()`:

1. **`missing` set never populated** — `packages.missing` was not accumulated across while-loop iterations. The `missing` variable stayed empty throughout execution.

2. **`all_missing` computed in wrong scope** — it was calculated inside the while loop using only the last iteration's `packages.missing`, instead of after the loop using the fully accumulated set.

3. **`brokendeps` included virtual packages** — packages already satisfied by bootstrap `Provides` (e.g., `awk` provided by `mawk`) were included in the output, causing `apt-get install awk` to fail.

## Fix

- **`plan.py`**: Accumulate `missing |= packages.missing` inside the loop. Move `all_missing` calculation after the loop. Filter `brokendeps` by `all_missing`.
- **`resolve.py`**: Add `iter_provided()` to extract `Provides` from bootstrap `dpkg/status`. Pass bootstrap-provided virtual packages to `Plan.resolve()` so they are excluded from missing.

## Testing

Before fix:
```
$ fab-plan-resolve plan/main --bootstrap=... | grep locales
# (empty - locales silently dropped)
```

After fix:
```
$ fab-plan-resolve plan/main --bootstrap=... | grep locales
locales                                                # plan/main
```

Full appliance build (NetBox 4.5.7) completes successfully with ISO and tar.gz generation.

## Impact

This bug affects **all appliance builds** on TKLDev with fab 1.1rc5. Without this fix, no appliance can build correctly — critical packages are missing from the root filesystem.